### PR TITLE
Change setup.py shebang to use python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2006, Red Hat, Inc.
 #


### PR DESCRIPTION
Changed `#!/usr/bin/env python` to `#!/usr/bin/env python3` for Python 3 compatibility.

@chimosky, @quozl please review.
Thanks